### PR TITLE
06 get all comments

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ const {
   getArticle,
   getAllArticles,
 } = require("./controllers/articles.controller");
+const { getComments } = require("./controllers/comments.controller");
 
 const app = express();
 
@@ -15,9 +16,11 @@ app.get("/api", getEndpoints);
 
 app.get("/api/topics", getTopics);
 
+app.get("/api/articles", getAllArticles);
+
 app.get("/api/articles/:article_id", getArticle);
 
-app.get("/api/articles", getAllArticles);
+app.get("/api/articles/:article_id/comments", getComments);
 
 app.all("*", endpointNotFound);
 

--- a/controllers/comments.controller.js
+++ b/controllers/comments.controller.js
@@ -1,0 +1,11 @@
+const { selectComments } = require("../models/comments.model");
+
+exports.getComments = ({ params }, res, next) => {
+  selectComments(params)
+    .then((comments) => {
+      res.status(200).send({ comments });
+    })
+    .catch((err) => {
+      next(err);
+    });
+};

--- a/endpoints.json
+++ b/endpoints.json
@@ -25,5 +25,36 @@
         }
       ]
     }
+  },
+  "GET /api/articles/:article_id": {
+    "description": "serves requested article",
+    "queries": [],
+    "exampleResponse": {
+      "article": {
+        "title": "Seafood substitutions are increasing",
+        "topic": "cooking",
+        "author": "weegembump",
+        "body": "Text from the article..",
+        "created_at": "2018-05-30T15:59:13.341Z",
+        "votes": 0,
+        "comment_count": 6
+      }
+    }
+  },
+  "GET /api/articles/:article_id/comments": {
+    "description": "serves an array of all comments for requested article",
+    "queries": ["sort_by", "order"],
+    "exampleResponse": {
+      "comments": [
+        {
+          "comment_id": 10,
+          "body": "git push origin master",
+          "article_id": 3,
+          "author": "icellusedkars",
+          "votes": 0,
+          "created_at": "2020-06-20T07:24:00.000Z"
+        }
+      ]
+    }
   }
 }

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -4,7 +4,7 @@ const { checkItemExists } = require("./utils");
 exports.selectArticle = ({ article_id }) => {
   const sql = "SELECT * FROM articles WHERE article_id = $1;";
   return db.query(sql, [article_id]).then(({ rows }) => {
-    return checkItemExists(rows);
+    return checkItemExists(rows) || rows[0];
   });
 };
 

--- a/models/comments.model.js
+++ b/models/comments.model.js
@@ -1,0 +1,12 @@
+const db = require("../db/connection");
+const { checkItemExists } = require("./utils");
+
+exports.selectComments = ({ article_id }) => {
+  const sql = `SELECT * FROM 
+  comments 
+  WHERE article_id = $1
+  ORDER BY created_at DESC;`;
+  return db.query(sql, [article_id]).then(({ rows }) => {
+    return checkItemExists(rows) || rows;
+  });
+};

--- a/models/utils.js
+++ b/models/utils.js
@@ -2,5 +2,4 @@ exports.checkItemExists = (rows) => {
   if (rows.length === 0) {
     return Promise.reject({ msg: "Not found", status: 404 });
   }
-  return rows[0];
 };


### PR DESCRIPTION
The endpoint GET /api/articles/:article_id/comments responds with an array of all comments for the requested article.
Comments are sorted newest to oldest.
Requesting comments for an article with no comments responds with error 404 - not found.
Requesting comments for an article with a nonexistent article id responds with error 404 - not found.
Requesting comments for an article with an invalid article id responds with error 400 - bad request.