### PR TITLE
18 update comment votes

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -230,8 +230,8 @@ describe("PATCH /api/articles/:article_id", () => {
         expect(error).toBe("Bad request");
       });
   });
-  test("400: Responds with appropriate error message when request body is incomplete", () => {
-    const update = {};
+  test("400: Responds with appropriate error message when request body does not have inc_votes property", () => {
+    const update = { inccc_votes: 6 };
     return request(app)
       .patch("/api/articles/4")
       .send(update)
@@ -240,7 +240,7 @@ describe("PATCH /api/articles/:article_id", () => {
         expect(error).toBe("Bad request");
       });
   });
-  test("400: Responds with appropriate error message when request body has invalid sql syntax", () => {
+  test("400: Responds with appropriate error message when value of inc_votes has invalid syntax", () => {
     const update = { inc_votes: "seven" };
     return request(app)
       .patch("/api/articles/4")
@@ -374,6 +374,76 @@ describe("POST /api/articles/:article_id/comments", () => {
     return request(app)
       .post("/api/articles/4/comments")
       .send(newComment)
+      .expect(400)
+      .then(({ body: { error } }) => {
+        expect(error).toBe("Bad request");
+      });
+  });
+});
+
+describe("PATCH /api/comments/:comment_id", () => {
+  test("200: Responds with updated comment object", () => {
+    const update = { inc_votes: 7 };
+    return request(app)
+      .patch("/api/comments/5")
+      .send(update)
+      .expect(200)
+      .then(({ body: { comment } }) => {
+        expect(comment).toMatchObject({
+          comment_id: 5,
+          body: "I hate streaming noses",
+          article_id: 1,
+          author: "icellusedkars",
+          votes: 7,
+          created_at: expect.any(String),
+        });
+      });
+  });
+  test("200: Votes are incremented correctly when there are preexisting votes", () => {
+    const update = { inc_votes: -10 };
+    return request(app)
+      .patch("/api/comments/1")
+      .send(update)
+      .expect(200)
+      .then(({ body: { comment } }) => {
+        expect(comment.votes).toBe(6);
+      });
+  });
+  test("404: Responds with appropriate error message when nonexistent comment id", () => {
+    const update = { inc_votes: -3 };
+    return request(app)
+      .patch("/api/comments/9000")
+      .send(update)
+      .expect(404)
+      .then(({ body: { error } }) => {
+        expect(error).toBe("Comment not found");
+      });
+  });
+  test("400: Responds with appropriate error message when invalid comment id", () => {
+    const update = { inc_votes: 2 };
+    return request(app)
+      .patch("/api/comments/banana")
+      .send(update)
+      .expect(400)
+      .then(({ body: { error } }) => {
+        expect(error).toBe("Bad request");
+      });
+  });
+  test("400: Responds with appropriate error message when request body does not have inc_votes property", () => {
+    const update = {};
+    return request(app)
+      .patch("/api/comments/4")
+      .send(update)
+      .expect(400)
+      .then(({ body: { error } }) => {
+        expect(error).toBe("Bad request");
+      });
+  });
+  test("400: Responds with appropriate error message when value of inc_votes has invalid syntax", () => {
+    const update = { inc_votes: "seven" };
+    return request(app)
+      .patch("/api/comments/4")
+      .send(update)
       .expect(400)
       .then(({ body: { error } }) => {
         expect(error).toBe("Bad request");

--- a/controllers/comments.controller.js
+++ b/controllers/comments.controller.js
@@ -2,6 +2,7 @@ const {
   selectComments,
   insertComment,
   deleteCommentFromDb,
+  updateComment,
 } = require("../models/comments.model");
 
 exports.getComments = ({ params }, res, next) => {
@@ -18,6 +19,16 @@ exports.postComment = ({ body, params }, res, next) => {
   insertComment(body, params)
     .then((comment) => {
       res.status(201).send({ comment });
+    })
+    .catch((err) => {
+      next(err);
+    });
+};
+
+exports.patchComment = ({ params, body }, res, next) => {
+  updateComment(params, body)
+    .then((comment) => {
+      res.status(200).send({ comment });
     })
     .catch((err) => {
       next(err);

--- a/endpoints.json
+++ b/endpoints.json
@@ -95,6 +95,23 @@
       ]
     }
   },
+  "PATCH /api/comments/:comment_id": {
+    "description": "updates requested comment",
+    "queries": [],
+    "exampleBody": {
+      "inc_votes": 9
+    },
+    "exampleResponse": {
+      "comment": {
+        "comment_id": 10,
+        "body": "git push origin master",
+        "article_id": 3,
+        "author": "icellusedkars",
+        "votes": 9,
+        "created_at": "2020-06-20T07:24:00.000Z"
+      }
+    }
+  },
   "DELETE /api/comments/:comment_id": {
     "description": "delete comment from article"
   },

--- a/models/comments.model.js
+++ b/models/comments.model.js
@@ -31,6 +31,23 @@ exports.insertComment = ({ username, body }, { article_id }) => {
     });
 };
 
+exports.updateComment = ({ comment_id }, { inc_votes }) => {
+  return checkValueExists({ comment_id })
+    .then(() => {
+      const sql = `SELECT votes FROM comments WHERE comment_id = $1;`;
+      return sqlReturnItem(sql, [comment_id]);
+    })
+    .then(({ votes }) => {
+      const updatedVotes = votes + inc_votes;
+      const sql = `UPDATE comments 
+      SET votes = $1
+      WHERE comment_id = $2
+      RETURNING *;`;
+      args = [updatedVotes, comment_id];
+      return sqlReturnItem(sql, args);
+    });
+};
+
 exports.deleteCommentFromDb = ({ comment_id }) => {
   return checkValueExists({ comment_id }).then(() => {
     const sql = `DELETE FROM 

--- a/routes/comments-router.js
+++ b/routes/comments-router.js
@@ -1,7 +1,10 @@
-const { deleteComment } = require("../controllers/comments.controller");
+const {
+  deleteComment,
+  patchComment,
+} = require("../controllers/comments.controller");
 
 const commentsRouter = require("express").Router();
 
-commentsRouter.delete("/:comment_id", deleteComment);
+commentsRouter.route("/:comment_id").delete(deleteComment).patch(patchComment);
 
 module.exports = commentsRouter;


### PR DESCRIPTION
The endpoint PATCH /api/comments/:comment_id updates votes for given comment and responds with the updated comment.
Requesting to patch a comment with a nonexistent comment id responds with error 404 - comment not found.
Requesting to patch a comment with an invalid comment id responds with error 400 - bad request.
Incorrect request body responds with error 400 - bad request.