### PR TITLE
20 get articles pagination

### DIFF
--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -3,7 +3,11 @@ const {
   createRef,
   formatComments,
 } = require("../db/seeds/utils");
-const { getCommentCount, checkValueExists } = require("../models/utils");
+const {
+  getCommentCount,
+  checkValueExists,
+  formatArticlesPage,
+} = require("../models/utils");
 const db = require("../db/connection");
 
 afterAll(() => {
@@ -183,6 +187,39 @@ describe("checkValueExists", () => {
         msg: "Topic not found",
         status: 404,
       });
+    });
+  });
+});
+
+describe("formatArticlesPage", () => {
+  test("returns correctly formatted response body containing articles property and total_count property", () => {
+    const articles = [
+      { author: "xgh", title: "ghb", total_count: 15 },
+      { author: "jksf", title: "interesting", total_count: 15 },
+    ];
+    const expectedResponse = {
+      total_count: 15,
+      articles: [
+        { author: "xgh", title: "ghb" },
+        { author: "jksf", title: "interesting" },
+      ],
+    };
+    expect(formatArticlesPage(articles)).toEqual(expectedResponse);
+  });
+  test("removes total_count property from individual article objects", () => {
+    const inputArticles = [
+      { title: "cool", total_count: 4 },
+      { title: "hello", total_count: 4 },
+    ];
+    const { articles } = formatArticlesPage(inputArticles);
+    articles.forEach((article) => {
+      expect(article.hasOwnProperty("total_count")).toBe(false);
+    });
+  });
+  test("returns rejected promise with correct error object if passed empty page", () => {
+    return expect(formatArticlesPage([])).rejects.toMatchObject({
+      msg: "Page not found",
+      status: 404,
     });
   });
 });

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -18,7 +18,7 @@ exports.getArticle = ({ params }, res, next) => {
 exports.getAllArticles = ({ query }, res, next) => {
   selectAllArticles(query)
     .then((articles) => {
-      res.status(200).send({ articles });
+      res.status(200).send(articles);
     })
     .catch((err) => {
       next(err);

--- a/endpoints.json
+++ b/endpoints.json
@@ -11,7 +11,7 @@
   },
   "GET /api/articles": {
     "description": "serves an array of all articles",
-    "queries": ["author", "topic", "sort_by", "order"],
+    "queries": ["author", "topic", "sort_by", "order", "limit", "p"],
     "exampleResponse": {
       "articles": [
         {

--- a/models/utils.js
+++ b/models/utils.js
@@ -50,3 +50,18 @@ exports.sqlReturnItem = (sql, args) => {
     return rows[0];
   });
 };
+
+exports.formatArticlesPage = (articles) => {
+  if (articles.length === 0) {
+    return Promise.reject({
+      status: 404,
+      msg: "Page not found",
+    });
+  }
+  const total_count = articles[0].total_count;
+  const formattedArticles = articles.map((article) => {
+    delete article.total_count;
+    return article;
+  });
+  return { total_count, articles: formattedArticles };
+};


### PR DESCRIPTION
Update GET /api/articles endpoint to respond with one page of articles and a total_count property. 
Page query 'p' allows navigation to required page number.
'limit' query allows client to customise page size. 
Default page number is one, default page size is 10. 
Requests with invalid query values are responded to with 400 - Invalid query values.
Requests for an empty page are responded to with 404 - Page not found