### PR TITLE
21 comments pagination

### DIFF
--- a/controllers/comments.controller.js
+++ b/controllers/comments.controller.js
@@ -5,10 +5,10 @@ const {
   updateComment,
 } = require("../models/comments.model");
 
-exports.getComments = ({ params }, res, next) => {
-  selectComments(params)
+exports.getComments = ({ params, query }, res, next) => {
+  selectComments(params, query)
     .then((comments) => {
-      res.status(200).send({ comments });
+      res.status(200).send(comments);
     })
     .catch((err) => {
       next(err);

--- a/models/utils.js
+++ b/models/utils.js
@@ -36,6 +36,7 @@ exports.checkValueExists = ({ username, article_id, comment_id, topic }) => {
     if (rows.length === 0) {
       return Promise.reject({ msg: `${itemName} not found`, status: 404 });
     }
+    return Promise.resolve("all is well");
   });
 };
 
@@ -51,17 +52,47 @@ exports.sqlReturnItem = (sql, args) => {
   });
 };
 
-exports.formatArticlesPage = (articles) => {
-  if (articles.length === 0) {
+exports.formatPageOfItems = (items, itemName) => {
+  if (items.length === 0) {
     return Promise.reject({
       status: 404,
       msg: "Page not found",
     });
   }
-  const total_count = articles[0].total_count;
-  const formattedArticles = articles.map((article) => {
-    delete article.total_count;
-    return article;
+  const total_count = items[0].total_count;
+  const formattedItems = items.map((item) => {
+    delete item.total_count;
+    return item;
   });
-  return { total_count, articles: formattedArticles };
+  if (itemName === "articles") {
+    return { total_count, articles: formattedItems };
+  }
+  if (itemName === "comments") {
+    return { total_count, comments: formattedItems };
+  }
+  return { total_count, items: formattedItems };
 };
+
+exports.queryError = () => {
+  return Promise.reject({
+    status: 400,
+    msg: "Invalid query values",
+  });
+};
+
+exports.testPageQueries = (limit, p) => {
+  const numberRegex = /^\d+$/;
+  if (!numberRegex.test(limit) || !numberRegex.test(p)) {
+    return this.queryError();
+  }
+  return Promise.resolve("all is well");
+};
+
+// exports.testArticleSortQueries = (sort_by, order) => {
+//   if (
+//     !validSortQueries.sort_by.includes(sort_by) ||
+//     !validSortQueries.order.includes(order)
+//   ) {
+//     return this.queryError;
+//   }
+// };


### PR DESCRIPTION
Update GET /api/articles/:article_id/comments endpoint to respond with one page of comments and a total_count property.
Page query 'p' allows navigation to required page number.
'limit' query allows client to customise page size.
Default page number is one, default page size is 10.
Requests with invalid query values are responded to with 400 - Invalid query values.
Requests for an empty page (where page number is not 1) are responded to with 404 - Page not found