### PR TITLE
22 post new topic

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -52,6 +52,62 @@ describe("GET /api/topics", () => {
   });
 });
 
+describe("POST /api/topics", () => {
+  test("201: Responds with the newly added topic", () => {
+    const newTopic = {
+      slug: "super",
+      description: "This is a new topic...",
+    };
+    return request(app)
+      .post("/api/topics")
+      .send(newTopic)
+      .expect(201)
+      .then(({ body: { topic } }) => {
+        expect(topic).toMatchObject({
+          slug: "super",
+          description: "This is a new topic...",
+        });
+      });
+  });
+  test("201: Topic description is not necessary", () => {
+    const newTopic = {
+      slug: "self-explanatory",
+    };
+    return request(app)
+      .post("/api/topics")
+      .send(newTopic)
+      .expect(201)
+      .then(({ body: { topic } }) => {
+        expect(topic.slug).toBe("self-explanatory");
+      });
+  });
+  test("400: Responds with appropriate error message when topic already exists", () => {
+    const newTopic = {
+      slug: "mitch",
+      description: "This had hoped to be a new topic...",
+    };
+    return request(app)
+      .post("/api/topics")
+      .send(newTopic)
+      .expect(400)
+      .then(({ body: { error } }) => {
+        expect(error).toBe("Topic already exists");
+      });
+  });
+  test("400: Responds with appropriate error message when request body is incomplete", () => {
+    const newTopic = {
+      description: "This was, at one point, a new topic...",
+    };
+    return request(app)
+      .post("/api/topics")
+      .send(newTopic)
+      .expect(400)
+      .then(({ body: { error } }) => {
+        expect(error).toBe("Bad request");
+      });
+  });
+});
+
 describe("GET /api/articles", () => {
   test("200: Responds with an array of article objects without a body property", () => {
     return request(app)

--- a/controllers/topics.controller.js
+++ b/controllers/topics.controller.js
@@ -1,7 +1,17 @@
-const { selectTopics } = require("../models/topics.model");
+const { selectTopics, insertTopic } = require("../models/topics.model");
 
 exports.getTopics = (req, res, next) => {
   selectTopics().then((topics) => {
     res.status(200).send({ topics });
   });
+};
+
+exports.postTopic = ({ body }, res, next) => {
+  insertTopic(body)
+    .then((topic) => {
+      res.status(201).send({ topic });
+    })
+    .catch((err) => {
+      next(err);
+    });
 };

--- a/endpoints.json
+++ b/endpoints.json
@@ -9,6 +9,14 @@
       "topics": [{ "slug": "football", "description": "Footie!" }]
     }
   },
+  "POST /api/topics": {
+    "description": "adds topic and serves newly added topic",
+    "queries": [],
+    "exampleBody": { "slug": "football", "description": "Footie!" },
+    "exampleResponse": {
+      "topic": { "slug": "football", "description": "Footie!" }
+    }
+  },
   "GET /api/articles": {
     "description": "serves an array of all articles",
     "queries": ["author", "topic", "sort_by", "order", "limit", "p"],

--- a/models/topics.model.js
+++ b/models/topics.model.js
@@ -1,6 +1,20 @@
-const { sqlReturnTable } = require("./utils");
+const { sqlReturnTable, sqlReturnItem } = require("./utils");
 
 exports.selectTopics = () => {
   const sql = "SELECT * FROM topics;";
   return sqlReturnTable(sql);
+};
+
+exports.insertTopic = ({ slug, description }) => {
+  const sql = `INSERT INTO topics (slug, description) 
+        VALUES ($1, $2) 
+        RETURNING *;`;
+  const args = [slug, description];
+  return sqlReturnItem(sql, args).catch((err) => {
+    let reason = err;
+    if (err.code === "23505") {
+      reason = { status: 400, msg: "Topic already exists" };
+    }
+    return Promise.reject(reason);
+  });
 };

--- a/routes/topics-router.js
+++ b/routes/topics-router.js
@@ -1,7 +1,7 @@
-const { getTopics } = require("../controllers/topics.controller");
+const { getTopics, postTopic } = require("../controllers/topics.controller");
 
 const topicsRouter = require("express").Router();
 
-topicsRouter.get("/", getTopics);
+topicsRouter.route("/").get(getTopics).post(postTopic);
 
 module.exports = topicsRouter;


### PR DESCRIPTION
The endpoint POST /api/topic adds a topic and responds with the newly added topic.
Requesting to post a topic with a slug that already exists responds with error 400 - topic already exists.
Requesting to post a topic with the slug missing responds with error 400 - bad request.
Topic description is optional.